### PR TITLE
fix(ekscluster): filtering for tags is omitted

### DIFF
--- a/aws/resources/eks.go
+++ b/aws/resources/eks.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gruntwork-io/cloud-nuke/config"
 	"github.com/gruntwork-io/cloud-nuke/logging"
 	"github.com/gruntwork-io/cloud-nuke/report"
-	"github.com/gruntwork-io/cloud-nuke/util"
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/hashicorp/go-multierror"
 )
@@ -34,12 +33,6 @@ func (clusters *EKSClusters) getAll(c context.Context, configObj config.Config) 
 func (clusters *EKSClusters) filter(clusterNames []*string, configObj config.Config) ([]*string, error) {
 	var filteredEksClusterNames []*string
 	for _, clusterName := range clusterNames {
-		// Since we already have the name here, avoid an extra API call by applying
-		// the name based config filter first.
-		if !configObj.EKSCluster.ShouldInclude(config.ResourceValue{Name: clusterName}) {
-			continue
-		}
-
 		describeResult, err := clusters.Client.DescribeCluster(
 			clusters.Context,
 			&eks.DescribeClusterInput{Name: clusterName})
@@ -50,7 +43,7 @@ func (clusters *EKSClusters) filter(clusterNames []*string, configObj config.Con
 		if !configObj.EKSCluster.ShouldInclude(config.ResourceValue{
 			Name: clusterName,
 			Time: describeResult.Cluster.CreatedAt,
-			Tags: util.ConvertStringPtrTagsToMap(aws.StringMap(describeResult.Cluster.Tags)),
+			Tags: describeResult.Cluster.Tags,
 		}) {
 			continue
 		}


### PR DESCRIPTION
## Description

Fixes #898.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Attention Grunts - if this PR adds support for a new resource, ensure the `nuke_sandbox` and `nuke_phxdevops` jobs in `.circleci/config.yml` have been updated with appropriate exclusions (either directly in the job or via the `.circleci/nuke_config.yml` file) to prevent nuking IAM roles, groups, resources, etc that are important for the test accounts.


## Release Notes (draft)

Updated `ekscluster` resource to allow proper filtering for time and tags without a name matcher.
